### PR TITLE
breakのカメラ位置調整

### DIFF
--- a/src/components/vrm/cameraControls.tsx
+++ b/src/components/vrm/cameraControls.tsx
@@ -103,7 +103,10 @@ export const CameraControls = forwardRef<CameraControlsDefault, unknown>(
         } else if (['break'].includes(mode)) {
           cameraControls.current.enabled = true
           if (md) {
+            cameraControls.current.setPosition(-1, 1, 4, true)
+            cameraControls.current.setTarget(0.3, 0, 0, true)
           } else {
+            cameraControls.current.setPosition(0, 1.5, 4, true)
           }
         }
       }


### PR DESCRIPTION
PC版は前よりすこしアップで机も映るように、
スマホ版は正面で少し上から見えるようにしました。